### PR TITLE
Properly forward commands with quoted strings

### DIFF
--- a/bin/rbenv-each
+++ b/bin/rbenv-each
@@ -24,7 +24,7 @@ for ruby in `rbenv versions --bare`; do
     echo -e "\033[1;34m[$ruby]:\033[0m \033[1;32m$@\033[0m";
     echo -e "\033[1;34m******************************************************************\033[0m";
   fi
-  RBENV_VERSION=$ruby $@
+  RBENV_VERSION=$ruby "$@"
   if [ $verbose = 1 ]; then
     echo
   fi


### PR DESCRIPTION
Makes stuff like this work:

```
rbenv each ruby -e "p Object.class"
```
