### PR TITLE
The $? variable rewritten before check

### DIFF
--- a/bin/rbenv-each
+++ b/bin/rbenv-each
@@ -24,6 +24,9 @@ for ruby in `rbenv versions --bare`; do
     echo -e "[$ruby]: $@";
     echo -e "******************************************************************";
   fi
+  if [[ $ruby != [1-2]* ]]; then
+    continue;
+  fi
   RBENV_VERSION=$ruby "$@"
   result=$?
   if [ $verbose = 1 ]; then


### PR DESCRIPTION
Hi

I found that `rbenv each` always report OK, even in one of the rubies fails.

This patch fixed the issue. Thanks
