### PR TITLE
Refactor how status works - remove "set -e"

### DIFF
--- a/bin/rbenv-each
+++ b/bin/rbenv-each
@@ -9,7 +9,6 @@
 #
 #    -v  Verbose mode. Prints a header for each ruby.
 #
-set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
 # Provide rbenv completions
@@ -55,9 +54,8 @@ for ruby in $(rbenv versions --bare); do
     echo -e "${GRAY}${header}${NORMAL}"
   fi
 
-  STATUS=0
-  RBENV_VERSION="$ruby" "$@" || STATUS=$?
-  [ $STATUS -eq 0 ] || failed_rubies="$failed_rubies $ruby"
+  RBENV_VERSION="$ruby" "$@"
+  [ $? -eq 0 ] || failed_rubies="$failed_rubies $ruby"
 
   [ -n "$verbose" ] && echo
 done


### PR DESCRIPTION
Hey @mislav - I personally find the way the status check is implemented in the script a tad confusing, so I'm offering two alternate implementations, one that removes `"set -e"` _(this one)_ and another one that keeps it _(see #18)_

This PR removes `"set -e"`, which means the status check can be implemented directly on top of `$?` without the need for the now superfluous `STATUS` variable.

IMO, `"set -e"` adds very little value to the script, which is why I think it's OK to remove it, but I appreciate that opinions may differ, which is why I also implemented an alternative in #18 that keeps it.