### PR TITLE
Refactor how status works - keep "set -e"

### DIFF
--- a/bin/rbenv-each
+++ b/bin/rbenv-each
@@ -55,9 +55,7 @@ for ruby in $(rbenv versions --bare); do
     echo -e "${GRAY}${header}${NORMAL}"
   fi
 
-  STATUS=0
-  RBENV_VERSION="$ruby" "$@" || STATUS=$?
-  [ $STATUS -eq 0 ] || failed_rubies="$failed_rubies $ruby"
+  RBENV_VERSION="$ruby" "$@" || failed_rubies="$failed_rubies $ruby"
 
   [ -n "$verbose" ] && echo
 done


### PR DESCRIPTION
Hey @mislav - I personally find the way the status check is implemented in the script a tad confusing, so I'm offering two alternate implementations, one that keeps `"set -e"` _(this one)_ and another one that removes it _(see #17)_

This PR keeps `"set -e"`, but combines the two pipelines into a single one to avoid the need for the superfluous `STATUS` variable.