### PR TITLE
Skip alias versions by default, add --aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ the output.
 ```
 $ rbenv each bundle install
 $ rbenv each -v rake test
+$ rbenv each --skip-aliases bundle check
 ```

--- a/bin/rbenv-each
+++ b/bin/rbenv-each
@@ -2,12 +2,15 @@
 #
 # Summary: Execute a command for each Ruby version
 #
-# Usage: rbenv each [-v] <command> [arg1 arg2...]
+# Usage: rbenv each [options] <command> [arg1 arg2...]
 #
-# Executes a command for each Ruby version by setting RBENV_VERSION.
+# Execute a command for each Ruby version by setting RBENV_VERSION.
 # Failures are collected and reported at the end.
 #
-#    -v  Verbose mode. Prints a header for each ruby.
+# Options:
+#    -h, --help      Print this help message
+#    -a, --aliases   Don't skip ruby versions that are aliases (symlinks)
+#    -v, --verbose   Verbose mode: print a header for each version version
 #
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
@@ -15,20 +18,42 @@ set -e
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
   echo -v
+  echo --verbose
+  echo -a
+  echo --aliases
   exit
 fi
 
-if [ "$1" = "-v" ]; then
-  verbose=1
-  shift
-fi
+usage() {
+    rbenv-help --usage each >&2
+    exit 1
+}
 
-case "$1" in
-""  | -* )
-  rbenv-help --usage each >&2
-  exit 1
-  ;;
-esac
+verbose=
+aliases=
+
+while [[ $1 == -* ]]; do
+    case "$1" in
+        -v|--verbose)
+            verbose=1
+            ;;
+        -a|--aliases)
+            aliases=1
+            ;;
+        -h|--help)
+            rbenv-help each >&2
+            exit 0
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+if [ $# -lt 1 ]; then
+    usage
+fi
 
 GRAY=""
 RED=""
@@ -46,7 +71,13 @@ failed_rubies=""
 
 trap "exit 1" INT
 
-for ruby in $(rbenv versions --bare); do
+if [ -n "$aliases" ]; then
+    opts=
+else
+    opts="--skip-aliases"
+fi
+
+for ruby in $(rbenv versions --bare $opts); do
   if [ -n "$verbose" ]; then
     header="===[$ruby]==================================================================="
     header="${header:0:72}"


### PR DESCRIPTION
By default, skip ruby versions that are aliases. I'm having a hard time
thinking of any reason you would want to run the command on the same
ruby version multiple times by default.

Also tweak the option parsing and usage messages in support of this
change.

With versions `2.1 => 2.1.7`, `2.1.6`, and `2.1.7`:

    $ rbenv each ruby --version
    ruby 2.1.6p336 (2015-04-13 revision 50298) [x86_64-linux]
    ruby 2.1.7p400 (2015-08-18 revision 51632) [x86_64-linux]

    $ rbenv each --aliases ruby --version
    ruby 2.1.7p400 (2015-08-18 revision 51632) [x86_64-linux]
    ruby 2.1.6p336 (2015-04-13 revision 50298) [x86_64-linux]
    ruby 2.1.7p400 (2015-08-18 revision 51632) [x86_64-linux]

Happy to revise / edit this PR as desired.