### PR TITLE
Skip aliases (symlinks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ $ rbenv help each
 Verbose mode will print a header for each ruby so you can distinguish
 the output.
 
+**note**: Aliases ([rbenv-aliases][]) or symlinks are skipped.
+
 ### Examples:
 
 ```
 $ rbenv each bundle install
 $ rbenv each -v rake test
 ```
+
+[rbenv-aliases]: https://github.com/rbenv/rbenv-aliases

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ rbenv help each
 Verbose mode will print a header for each ruby so you can distinguish
 the output.
 
-**note**: Aliases ([rbenv-aliases][]) or symlinks are skipped.
+**Note**: [Version aliases][rbenv-aliases] (versions that are just symlinks pointing to another rbenv version) are skipped when iterating through the list of rbenv versions.
 
 ### Examples:
 

--- a/bin/rbenv-each
+++ b/bin/rbenv-each
@@ -49,7 +49,7 @@ failed_rubies=""
 
 trap "exit 1" INT
 
-for ruby in $(rbenv versions --bare); do
+for ruby in $(rbenv versions --bare --skip-aliases); do
   if [ -n "$verbose" ]; then
     header="===[$ruby]==================================================================="
     header="${header:0:72}"


### PR DESCRIPTION
Aliased rubies (via rbenv-aliases or manual symlinks) mean that the same
ruby is invoked multiple times. (As the target ruby, and again for each
alias that points to said ruby.)

This change now omits aliases from iteration so rbenv-each now only invokes
the command for truly distinct rubies.