### PR TITLE
Remove superfluous `mkdir` step in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 To install rbenv-each, clone this repository into your rbenv plugins directory. (You'll need a recent version of rbenv that supports plugin bundles.)
 
-
 ```
-$ mkdir -p "$(rbenv root)"/plugins
 $ git clone https://github.com/rbenv/rbenv-each.git "$(rbenv root)"/plugins/rbenv-each
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 To install rbenv-each, clone this repository into your rbenv plugins directory. (You'll need a recent version of rbenv that supports plugin bundles.)
 
 ```
-$ git clone https://github.com/rbenv/rbenv-each.git "$(rbenv root)"/plugins/rbenv-each
+git clone https://github.com/rbenv/rbenv-each.git "$(rbenv root)"/plugins/rbenv-each
 ```
 
 ## Usage


### PR DESCRIPTION
@mislav / @sstephenson - similar to the changes in rbenv/rbenv-vars#30, this PR simplifies the installation instructions somewhat by removing the superfluous `mkdir` step:  `git clone` will take care of creating what it calls the "leading directories", so there's no need to explicitly create the `plugins/` directory beforehand!

See discussion in this thread: https://github.com/rbenv/rbenv-vars/pull/30#discussion_r60699837
